### PR TITLE
ACPI: resources: Add Medion S17413 to IRQ override quirk

### DIFF
--- a/drivers/acpi/resource.c
+++ b/drivers/acpi/resource.c
@@ -400,6 +400,13 @@ static const struct dmi_system_id medion_laptop[] = {
 			DMI_MATCH(DMI_BOARD_NAME, "M17T"),
 		},
 	},
+	{
+		.ident = "MEDION S17413",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "MEDION"),
+			DMI_MATCH(DMI_BOARD_NAME, "M1xA"),
+		},
+	},
 	{ }
 };
 


### PR DESCRIPTION
Add DMI info of the S17413 in the IRQ override quirk table, just like the P15651 & S17405 previously.

See https://bugzilla.kernel.org/show_bug.cgi?id=213031#c91.

Test build: [vmlinuz-6.2.0-0-generic.gz](https://github.com/obiwac/linux/files/10787917/vmlinuz-6.2.0-0-generic.gz)